### PR TITLE
Fix/maintanability issues

### DIFF
--- a/src/dependency-module.ts
+++ b/src/dependency-module.ts
@@ -29,11 +29,7 @@ export abstract class StaticDependencyModule<T> extends DependencyModule<T> {
   }
 }
 
-export class ValueDependencyModule<T> extends StaticDependencyModule<T> {
-  constructor(value: T) {
-    super(value);
-  }
-}
+export class ValueDependencyModule<T> extends StaticDependencyModule<T> {}
 
 export abstract class DynamicDependencyModule<T> extends DependencyModule<T> {
   readonly lifeCycle: ModuleLifeCycle;

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -45,23 +45,21 @@ function splitParams(paramsString: string): string[] {
     if (inString) {
       current += char;
       if (char === inString && paramsString[i - 1] !== "\\") inString = null;
-      continue;
-    }
-
-    if (char === "'" || char === '"' || char === "`") {
+    } else if (char === "'" || char === '"' || char === "`") {
       inString = char;
       current += char;
-      continue;
-    }
-
-    if ("{[(".includes(char)) depth++;
-    if ("}])".includes(char)) depth--;
-    if (char === "," && depth === 0) {
+    } else if ("{[(".includes(char)) {
+      depth++;
+      current += char;
+    } else if ("}])".includes(char)) {
+      depth--;
+      current += char;
+    } else if (char === "," && depth === 0) {
       params.push(current);
       current = "";
-      continue;
+    } else {
+      current += char;
     }
-    current += char;
   }
   if (current.trim()) params.push(current);
   return params;

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -5,8 +5,9 @@ export function getParametersNames(fn: Function): string[] {
 
   // Handle class constructors
   if (/^class\s/.test(fnString)) {
-    const constructorMatch = fnString.match(/constructor\s*\(([^)]*)\)/s);
-    if (!constructorMatch || !constructorMatch[1]) return [];
+    const constructorRegex = /constructor\s*\(([^)]*)\)/s;
+    const constructorMatch = constructorRegex.exec(fnString);
+    if (!constructorMatch?.[1]) return [];
     fnString = `(${constructorMatch[1]}) => {}`;
   }
 
@@ -20,11 +21,13 @@ export function getParametersNames(fn: Function): string[] {
 }
 
 function extractParamsString(fnString: string): string | null {
-  let match = fnString.match(/^[^(]*\(\s*([^)]*)\)/s);
+  let paramRegex = /^[^(]*\(\s*([^)]*)\)/s;
+  let match = paramRegex.exec(fnString);
   if (match) return match[1];
 
   // Try to match single param arrow function: x => x*2
-  match = fnString.match(/^([a-zA-Z0-9_$]+)\s*=>/);
+  let arrowParamRegex = /^([a-zA-Z0-9_$]+)\s*=>/;
+  match = arrowParamRegex.exec(fnString);
   if (match) return match[1];
 
   return null;

--- a/src/module-container.ts
+++ b/src/module-container.ts
@@ -12,9 +12,10 @@ export type ModuleDescription = {
 };
 
 export class ModuleContainer {
-  private modules: Map<string, DependencyModule<any>> = new Map();
-  private rootModules: Map<string, DependencyModule<any>> = new Map();
-  private scopes: Map<string, Map<string, DependencyModule<any>>> = new Map();
+  private readonly modules: Map<string, DependencyModule<any>> = new Map();
+  private readonly rootModules: Map<string, DependencyModule<any>> = new Map();
+  private readonly scopes: Map<string, Map<string, DependencyModule<any>>> =
+    new Map();
 
   async resolveModule<T>(name: string, scopeName?: string): Promise<T> {
     if (scopeName && !this.scopes.has(scopeName)) {

--- a/tests/dependency-module.test.ts
+++ b/tests/dependency-module.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach } from "vitest";
+import { describe, it, expect } from "vitest";
 import {
   ModuleLifeCycle,
   StaticDependencyModule,

--- a/tests/module-container.test.ts
+++ b/tests/module-container.test.ts
@@ -126,7 +126,6 @@ describe("ModuleContainer", () => {
 
     const modules = container.listModules();
 
-    console.log("MY MODULES => \n\n", modules, "\n");
     expect(modules).toEqual(
       expect.arrayContaining([
         expect.objectContaining({


### PR DESCRIPTION
- Reduce cognitive complexity
- Remove unnecessary code (unused imports, useless constructors and `console.log`)
- Replace `.match` by `RegExp.exec`
- Change class properties to readonly